### PR TITLE
Implement support for GeoPackage (.gpkg) geometries

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,9 @@ import tempfile
 import zipfile
 import os
 import xml.etree.ElementTree as ET
+import fiona
+from shapely.geometry import shape, mapping
+
 
 st.set_page_config(
     page_title="Wildfire Burn Severity Analysis",
@@ -331,6 +334,29 @@ def satCollection(cloudRate, initialDate, updatedDate, aoi):
     collection = collection.map(clipCollection)
     return collection
 
+# File Parser: GeoPackage (`.gpkg`)
+def parse_geopackage(upload_file):
+
+    # prepare geometry
+    geometry_list = []
+    
+    with fiona.open(upload_file) as fu:
+        for feat in fu:
+            # Convert geometry to a Shapely geometry object
+            geom = shape(feat["geometry"])
+
+            # handle basic polygon
+            if geom.geom_type == "Polygon":
+                geometry_list.append(ee.Geometry.Polygon(list(geom.exterior.coords)))
+            
+            # handle multipolygon
+            elif geom.geom_type == "MultiPolygon":
+                coords = [list(poly.exterior.coords) for poly in geom.geoms]
+                geometry_list.append(ee.Geometry.MultiPolygon(coords))
+    
+    return geometry_list
+
+
 # File Parser: CSV
 # column name variations found in CSV datasets 
 COLUMN_SYNONYMS = {
@@ -452,6 +478,24 @@ def upload_files_proc(upload_files):
         file_name = getattr(upload_file, 'name').lower()
         # reset file pointer if it was read before
         upload_file.seek(0)
+
+        # GeoPackage file parser
+        if file_name.endswith(".gpkg"):
+            # store gpkg into a temporary file for Fiona
+            with tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False) as tmp:
+                # write uploaded file content to temp file
+                tmp.write(upload_file.getbuffer())
+                # write data to disk for readability
+                tmp.flush()
+                # parse temporary geopackage
+                gpkg_geoms = parse_geopackage(tmp.name)
+            
+            geometry_aoi_list.extend(gpkg_geoms)
+
+            if gpkg_geoms:
+                last_uploaded_centroid = gpkg_geoms[0].centroid(maxError=1).getInfo()["coordinates"]
+            
+            continue
 
         # CSV file parser
         if file_name.endswith(".csv"):


### PR DESCRIPTION
# Description

This PR implements a dedicated parser for **GeoPackage (`.gpkg`)** files to support polygon and multipolygon geometry uploads.

The new parser leverages **Fiona** for file reading and **Shapely** for geometry conversion, returning compatible `ee.Geometry` objects for integration with the existing Streamlit upload workflow.

Closes #18

---

## 📋 Type of Change

Mark with an [x] what applies: 

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 🔧 Enhancement (improving existing functionality/code)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (changes that cause existing functionality to not work)
- [ ] 📖 Documentation update
- [x] 📦 New dependency (list below)

If new dependencies were added, list them here:
- Fiona and Shapely

---

## ✅ Checklist

Before submitting your PR, confirm the following:

- [x] My branch is based on **`streamlit-dev`** (not `streamlit-main`).
- [x] I made the Pull Request against the `streamlit-dev`.
- [x] I have tested the app locally and verified my changes.
- [x] I documented new/modified functionality in code or docs.
- [x] I gave my PR a clear and descriptive title.
- [x] I linked the relevant issue(s).

---

## 🌱 Notes

- The parser reads `.gpkg` geometries using **Fiona**, then constructs **Shapely** objects for clean conversion into `ee.Geometry` instances.
- Supports both **Polygon** and **MultiPolygon** geometries.
- Temporary files are used to enable Fiona compatibility with Streamlit uploads (`NamedTemporaryFile` + `.getbuffer()` + `.flush()`).

---

![](https://raw.githubusercontent.com/IndigoWizard/Baby-Yoda-on-a-Trip/main/BabyYodaSprite.gif) “Follow this guide, you must.”
